### PR TITLE
リファクタリング

### DIFF
--- a/app/src/helper/formatInsertValue.ts
+++ b/app/src/helper/formatInsertValue.ts
@@ -1,0 +1,11 @@
+// ['FF:FF:FF:FF:FF:F1', 'FF:FF:FF:FF:FF:F2'] => ('FF:FF:FF:FF:FF:F1'),('FF:FF:FF:FF:FF:F2')
+export const formatInsertValue = (data: string[]) => {
+  let formated = '';
+  const lastData = data.length - 1;
+  data.forEach((ma, i) => {
+    formated += i !== lastData ? `('${ma}'),` : `('${ma}')`
+  })
+
+  return formated;
+
+}

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -1,7 +1,8 @@
 import express from 'express'
 import { Pool } from 'pg'
-import axios from 'axios'
+// import axios from 'axios'
 import dotenv from 'dotenv'
+import { formatInsertValue } from './helper/formatInsertValue'
 
 const main = () => {
   dotenv.config()
@@ -26,7 +27,7 @@ const main = () => {
 
     try {
       const client = await pool.connect()
-      const result = await client.query('INSERT INTO member_list VALUES ($1,$2)', [name, macaddress])
+      const result = await client.query('INSERT INTO member_list VALUES ($1, $2)', [name, macaddress])
       console.log("result", result)
       client.release()
     } catch (err) {
@@ -39,10 +40,14 @@ const main = () => {
     anyMacaddress: string[];
   }
 
-  // type RegularUser = {
-  //   name: string;
-  //   macaddress: string;
-  // }
+  type MemberList = {
+    name?: string;
+    macaddress?: string;
+  }
+
+  type ActiveMember = {
+    macaddress: string;
+  }
 
   app.post("/update", async (req, res) => {
     const client = await pool.connect()
@@ -54,37 +59,31 @@ const main = () => {
 
     // macaddresの検証
     try {
-      const { rows: currentMember } = await client.query('SELECT * from active_member')
-      console.log("currentMember", currentMember)
+      const { rows: prevMacaddress } = await client.query<ActiveMember>('SELECT * from active_member')
+      console.log("prevMacaddress", prevMacaddress)
 
-      let joinMember: string[] = []
+      const stayMember: string[] = []
+      const joinMember: string[] = []
       const exitMember: string[] | null = [];
-
-      // active memberがいない時
-      if (currentMember.length === 0 && reqMacaddress.length !== 0) {
-        joinMember = [...reqMacaddress]
-      }
 
       // メンバーが全員退出した時
       if (reqMacaddress.length === 0) {
         await client.query('DELETE FROM active_member')
+
         client.release()
         res.end()
-
         return
       }
 
       // ずっといる人
-      const stayMember: string[] = []
-      currentMember.forEach(actMem => {
+      prevMacaddress.forEach(actMem => {
         if (reqMacaddress.includes(actMem.macaddress)) {
           stayMember.push(actMem.macaddress)
         }
       })
-      console.log("staymemver", stayMember)
 
       // 退出した人
-      currentMember.forEach(actMem => {
+      prevMacaddress.forEach(actMem => {
         if (!stayMember.includes(actMem.macaddress)) {
           exitMember.push(actMem.macaddress)
         }
@@ -97,43 +96,39 @@ const main = () => {
         }
       })
 
+      console.log('stayMember', stayMember)
       console.log('joinMember', joinMember)
       console.log('exitMember', exitMember)
 
       if (joinMember.length !== 0) {
-        console.log('exec insert')
-        joinMember.forEach(async (ma) => {
-          await client.query('INSERT INTO active_member VALUES ($1)', [ma])
-        })
-        console.log('success insert join member')
-
+        console.log('excute insert')
+        console.log('formated', formatInsertValue(joinMember))
+        await client.query(`INSERT INTO active_member (macaddress) VALUES ${formatInsertValue(joinMember)}`)
 
         // Slackに送信
-
-        const joinMemberName = []
         console.log('start send slack!')
-        for (let i = 0; i < joinMember.length; i++) {
-          const { rows: name } = await client.query('SELECT name FROM member_list WHERE macaddress=($1)', [joinMember[i]])
-          joinMemberName.push(name[0].name)
-        }
-        console.log(joinMemberName)
-        joinMemberName.forEach(async name => {
-          const headers = {
-            'Content-Type': 'application/json',
-            Authorization: process.env.SLACK_API_KEY,
-          };
-          const data = {
-            channel: process.env.SLACK_CHANNEL_ID,
-            text: name
-          };
-          const { status } = await axios({
-            method: 'post',
-            url: 'https://slack.com/api/chat.postMessage',
-            data,
-            headers,
-          });
-          console.log(status)
-        })
+        // MACアドレスから名前を入手
+        // https://stackoverflow.com/questions/10720420/node-postgres-how-to-execute-where-col-in-dynamic-value-list-query/10829760#10829760
+        const { rows: joinMemberNames } = await client.query<MemberList>('SELECT name FROM member_list WHERE macaddress = ANY($1::text[])', [joinMember])
+        console.log('joinMemberNames', joinMemberNames)
+
+        // joinMemberName.forEach(async name => {
+        //   const headers = {
+        //     'Content-Type': 'application/json',
+        //     Authorization: process.env.SLACK_API_KEY,
+        //   };
+        //   const data = {
+        //     channel: process.env.SLACK_CHANNEL_ID,
+        //     text: name
+        //   };
+        //   const { status } = await axios({
+        //     method: 'post',
+        //     url: 'https://slack.com/api/chat.postMessage',
+        //     data,
+        //     headers,
+        //   });
+        //   console.log(status)
+        // })
       }
 
       if (exitMember.length !== 0) {
@@ -176,13 +171,14 @@ const main = () => {
     }
   })
 
-  app.get("/testdb", async (_, res) => {
+  app.get("/healthDb", async (_, res) => {
     try {
       const client = await pool.connect()
-      const result = await client.query('SELECT * FROM member_list')
+      const result = await client.query('SELECT * FROM member_list LIMIT 1')
       const results = { 'test_member_list': (result) ? result.rows : null }
       res.send(results)
       client.release()
+      res.end()
     } catch (err) {
       console.log(err)
       res.send("ERR: " + err)

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -64,7 +64,7 @@ const main = () => {
       if (currentMember.length === 0 && reqMacaddress.length !== 0) {
         joinMember = [...reqMacaddress]
       }
-      
+
       // メンバーが全員退出した時
       if (reqMacaddress.length === 0) {
         await client.query('DELETE FROM active_member')
@@ -73,11 +73,11 @@ const main = () => {
 
         return
       }
-      
+
       // ずっといる人
-      const stayMember:string[] = []
+      const stayMember: string[] = []
       currentMember.forEach(actMem => {
-        if(reqMacaddress.includes(actMem.macaddress)){
+        if (reqMacaddress.includes(actMem.macaddress)) {
           stayMember.push(actMem.macaddress)
         }
       })
@@ -85,7 +85,7 @@ const main = () => {
 
       // 退出した人
       currentMember.forEach(actMem => {
-        if(!stayMember.includes(actMem.macaddress)){
+        if (!stayMember.includes(actMem.macaddress)) {
           exitMember.push(actMem.macaddress)
         }
       })
@@ -112,12 +112,12 @@ const main = () => {
 
         const joinMemberName = []
         console.log('start send slack!')
-        for (let i=0; i<joinMember.length; i++) {
-          const {rows: name} = await client.query('SELECT name FROM member_list WHERE macaddress=($1)',[joinMember[i]])
+        for (let i = 0; i < joinMember.length; i++) {
+          const { rows: name } = await client.query('SELECT name FROM member_list WHERE macaddress=($1)', [joinMember[i]])
           joinMemberName.push(name[0].name)
         }
         console.log(joinMemberName)
-        joinMemberName.forEach( async name => {
+        joinMemberName.forEach(async name => {
           const headers = {
             'Content-Type': 'application/json',
             Authorization: process.env.SLACK_API_KEY,
@@ -158,12 +158,12 @@ const main = () => {
   app.get("/getAllActiveMember", async (_, res) => {
     try {
       const client = await pool.connect()
-      const {rows: activeMac } = await client.query('SELECT * FROM active_member')
+      const { rows: activeMac } = await client.query('SELECT * FROM active_member')
       console.log(activeMac)
 
       const activeMemberNames = []
-      for (let i=0 ; i < activeMac.length; i++) {
-        const {rows: name} = await client.query('SELECT name FROM member_list WHERE macaddress=($1)', [activeMac[i].macaddress])
+      for (let i = 0; i < activeMac.length; i++) {
+        const { rows: name } = await client.query('SELECT name FROM member_list WHERE macaddress=($1)', [activeMac[i].macaddress])
         activeMemberNames.push(name[0].name)
       }
       console.log(activeMemberNames)
@@ -172,7 +172,7 @@ const main = () => {
       res.end()
     } catch (err) {
       console.log(err)
-      res.send("ERR: " + err )
+      res.send("ERR: " + err)
     }
   })
 

--- a/app/src/utils/sendMessageToSlack.ts
+++ b/app/src/utils/sendMessageToSlack.ts
@@ -1,0 +1,30 @@
+import axios from 'axios'
+import { MemberList } from '../index'
+
+const createNameList = (members: MemberList[]) => {
+  let nameList = "";
+  members.forEach((members) => {
+    nameList += `${members.name} \n`
+  })
+  return nameList
+}
+
+export const sendMessageToSlack = async (members: MemberList[]) => {
+  const names = createNameList(members)
+  console.log('names', names)
+
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: process.env.SLACK_API_KEY,
+  };
+  const data = {
+    channel: process.env.SLACK_CHANNEL_ID,
+    text: names
+  };
+  await axios({
+    method: 'post',
+    url: 'https://slack.com/api/chat.postMessage',
+    data,
+    headers,
+  });
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,8 @@ services:
     container_name: node_app
     volumes:
       - ./app:/usr/src/app
-      - /usr/src/app/node_modules
+      - satoruchan_node_modules:/usr/src/app/node_modules
     command: yarn dev-tsd
 volumes:
   satoruchan_db_data: {}
+  satoruchan_node_modules: {}


### PR DESCRIPTION
- TSのany型を修正
currentMemberがany型だったため修正

- 変数名を修正
currentMemberは、updateハンドラ内では過去の値となるため、変数名をprevMacaddressに変更

- SQLの修正
for文の中でSQLを叩くと、SQLの構文解析などがループごとに毎回発生してパフォーマンスが悪くなると考えた。
SELECTではWHERE IN句を使い、DLETEやINSERTはヘルパー関数により、一回のSQL文で複数の値を指定するように変更。

- Slackにメッセージを送信する処理の切り離し
メッセージを送信する関数を作成した